### PR TITLE
Add AccountPrivateKey to the PersistKind enum

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -69,7 +69,7 @@ impl<P: Persist> Directory<P> {
     /// account is active and working.
     pub fn account(&self, contact_email: &str) -> Result<Account<P>> {
         // key in persistence for acme account private key
-        let pem_key = PersistKey::new(&contact_email, PersistKind::PrivateKey, "acme_account");
+        let pem_key = PersistKey::new(&contact_email, PersistKind::AccountPrivateKey, "acme_account");
 
         // Get the key from a saved PEM, or from creating a new
         let mut is_new = false;

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -16,6 +16,8 @@ use crate::Result;
 /// Kinds of [persistence keys](struct.PersistKey.html).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum PersistKind {
+    /// Persisted account private key.
+    AccountPrivateKey,
     /// Persisted private key.
     PrivateKey,
     /// Persisted certificate.
@@ -27,6 +29,7 @@ impl PersistKind {
         match self {
             PersistKind::Certificate => "crt",
             PersistKind::PrivateKey => "key",
+            PersistKind::AccountPrivateKey => "key",
         }
     }
 }


### PR DESCRIPTION
The current implementation allows to create a custom storage objects
that implements Persist. However, in such a custom storage object, it is
hard (yet not impossible) to discriminate private keys for certificates
from private keys from accounts. Adding AccountPrivateKey to the
PersistKind solves this problem while keeping backward compatibility
with the default persist objects.