### PR TITLE
recognizes alternate jwt verification error

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -47,7 +47,8 @@ impl ApiProblem {
         self._type == "badNonce"
     }
     pub fn is_jwt_verification_error(&self) -> bool {
-        self._type == "urn:acme:error:malformed"
+        (self._type == "urn:acme:error:malformed"
+            || self._type == "urn:ietf:params:acme:error:malformed")
             && self
                 .detail
                 .as_ref()


### PR DESCRIPTION
I tried acme-lib and it failed due to what appears to be a renamed error. I added code to support the old error name and the new name and it worked.