### PR TITLE
Make email optional

### DIFF
--- a/src/acc/mod.rs
+++ b/src/acc/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use self::akey::AcmeKey;
 pub(crate) struct AccountInner<P: Persist> {
     pub persist: P,
     pub transport: Transport,
-    pub contact_email: String,
+    pub contact_email: Option<String>,
     pub api_account: ApiAccount,
     pub api_directory: ApiDirectory,
 }
@@ -46,7 +46,7 @@ impl<P: Persist> Account<P> {
     pub(crate) fn new(
         persist: P,
         transport: Transport,
-        contact_email: &str,
+        contact_email: Option<&str>,
         api_account: ApiAccount,
         api_directory: ApiDirectory,
     ) -> Self {
@@ -54,7 +54,7 @@ impl<P: Persist> Account<P> {
             inner: Arc::new(AccountInner {
                 persist,
                 transport,
-                contact_email: contact_email.into(),
+                contact_email: contact_email.map(String::from),
                 api_account,
                 api_directory,
             }),
@@ -69,8 +69,8 @@ impl<P: Persist> Account<P> {
     }
 
     /// Contact email for this account.
-    pub fn contact_email(&self) -> &str {
-        &self.inner.contact_email
+    pub fn contact_email(&self) -> Option<&str> {
+        self.inner.contact_email.as_deref()
     }
 
     /// Get an already issued and [downloaded] certificate.
@@ -86,7 +86,7 @@ impl<P: Persist> Account<P> {
     /// [valid days left]: struct.Certificate.html#method.valid_days_left
     pub fn certificate(&self, primary_name: &str) -> Result<Option<Certificate>> {
         // details needed for persistence
-        let realm = &self.inner.contact_email;
+        let realm = self.inner.contact_email.as_deref().unwrap_or("");
         let persist = &self.inner.persist;
 
         // read primary key

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -283,6 +283,22 @@ pub struct CertOrder<P: Persist> {
 
 impl<P: Persist> CertOrder<P> {
     /// Request download of the issued certificate.
+    pub fn download_cert(self) -> Result<Certificate> {
+        //
+        let url = self.order.api_order.certificate.expect("certificate url");
+        let inner = self.order.inner;
+
+        let res = inner.transport.call(&url, &ApiEmptyString)?;
+
+        let pkey_pem_bytes = self.private_key.private_key_to_pem_pkcs8().expect("to_pem");
+        let pkey_pem = String::from_utf8_lossy(&pkey_pem_bytes);
+
+        let cert = res.into_string()?;
+
+        Ok(Certificate::new(pkey_pem.to_string(), cert))
+    }
+
+    /// Request download of the issued certificate.
     ///
     /// When downloaded, the certificate and key will be saved in the
     /// persistence. They can later be retreived using [`Account::certificate`].

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -293,7 +293,7 @@ impl<P: Persist> CertOrder<P> {
         let primary_name = self.order.api_order.domains()[0].to_string();
         let url = self.order.api_order.certificate.expect("certificate url");
         let inner = self.order.inner;
-        let realm = inner.contact_email.clone();
+        let realm = inner.contact_email.as_deref().unwrap_or(&"");
 
         let res = inner.transport.call(&url, &ApiEmptyString)?;
 


### PR DESCRIPTION
This also contains code to allow accessing the generated certificate without sending it to persistence. I've tested this with the staging acme servers.