### PR TITLE
Make some marker types public so return types are representable

### DIFF
--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -31,7 +31,7 @@ use crate::Result;
 
 mod auth;
 
-pub use self::auth::{Auth, Challenge};
+pub use self::auth::{Auth, Challenge, Http, Dns, TlsAlpn};
 
 /// The order wrapped with an outer façade.
 pub(crate) struct Order<P: Persist> {


### PR DESCRIPTION
Without this, some return values from public API cannot be
stored in external structs because it is not possible to name
the return type.