### PR TITLE
Mark contact field as optional to fix deserialize failure

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -119,6 +119,7 @@ impl ApiDirectoryMeta {
 pub struct ApiAccount {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(default)]
     pub contact: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub termsOfServiceAgreed: Option<bool>,


### PR DESCRIPTION
The api response changed and the contact field may not be present anymore, causing this error:
```
[2021-09-22T09:47:55Z ERROR acme_redirect::renew] Failed to renew ("redacted.com"): Fail to get certificate "redacted.com": missing field `contact` at line 13 column 1
```
Sending this patch upstream from https://github.com/kpcyrd/acme-micro/pull/5 that was fixed in acme-micro 0.12.0 and acme-redirect 0.5.3.