### PR TITLE
Fix: normalize domain name for FilePersist

### DIFF
--- a/src/persist.rs
+++ b/src/persist.rs
@@ -173,7 +173,7 @@ impl Persist for FilePersist {
 }
 
 fn file_name_of(dir: &Path, key: &PersistKey) -> PathBuf {
-    let mut f_name = dir.join(key.to_string());
+    let mut f_name = dir.join(key.to_string().to_lowercase());
     f_name.set_extension(key.kind.name());
     f_name
 }


### PR DESCRIPTION
Currently acme-lib stores all certificates in lowercase form, which means `Account<FilePersist>::certificate` will always return None if called with an domain name containing any uppercase characters. This fix will change `FilePersist` such that domain names are always written in lower case form.