### PR TITLE
Make contact of ApiAccount optional, as in RFC8555

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -119,7 +119,8 @@ impl ApiDirectoryMeta {
 pub struct ApiAccount {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    pub contact: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub termsOfServiceAgreed: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -73,7 +73,7 @@ impl<P: Persist> Directory<P> {
     pub fn account(&self, contact_email: &str) -> Result<Account<P>> {
         // Contact email is the persistence realm when using this method.
         let contact = vec![format!("mailto:{}", contact_email)];
-        self.account_with_realm(contact_email, contact)
+        self.account_with_realm(contact_email, Some(contact))
     }
 
     /// Access an account using a lower level method. The contact is optional
@@ -92,7 +92,11 @@ impl<P: Persist> Directory<P> {
     ///
     /// Either way the `newAccount` API endpoint is called and thereby ensures the
     /// account is active and working.
-    pub fn account_with_realm(&self, realm: &str, contact: Vec<String>) -> Result<Account<P>> {
+    pub fn account_with_realm(
+        &self,
+        realm: &str,
+        contact: Option<Vec<String>>,
+    ) -> Result<Account<P>> {
         // key in persistence for acme account private key
         let pem_key = PersistKey::new(realm, PersistKind::AccountPrivateKey, "acme_account");
 


### PR DESCRIPTION
Where ever I go @algesten is making cools stuff. 💯 

This PR is to change the ApiAccount `contact` field to optional.

According to the RFC, the field should be optional:
https://www.rfc-editor.org/rfc/rfc8555#section-7.1.2
https://www.rfc-editor.org/rfc/rfc8555#section-7.3
`contact (optional, array of string)`

In addition to the RFC having the contact as optional, from my testing today with `acme-lib` the contact field is optional for Let's Encrypt.
(Today, I was able to use `acme-lib` with an ApiAccount without a JSON `contact` field, and I was able to create a certificate.)




