### PR TITLE
abstract away the http client and ssl implementation so others can be used instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,13 @@ openssl = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = "0.1"
-ureq = "1"
+ureq = { version = "1", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
 futures = "0.1.25"
 hyper = "0.12"
 regex = "1.3"
+
+[features]
+default = ["ureq"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 base64 = "0.13"
 lazy_static = "1"
 log = "0.4"
-openssl = "0.10"
+openssl = { version = "0.10", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 time = "0.1"
@@ -27,4 +27,4 @@ hyper = "0.12"
 regex = "1.3"
 
 [features]
-default = ["ureq"]
+default = ["ureq", "openssl"]

--- a/src/acc/akey.rs
+++ b/src/acc/akey.rs
@@ -1,42 +1,35 @@
-use openssl::ec::EcKey;
-use openssl::pkey;
-
-use crate::cert::EC_GROUP_P256;
-use crate::Result;
+use crate::crypto::{Crypto, PKey};
+use crate::jwt::Jwk;
 
 #[derive(Clone, Debug)]
-pub(crate) struct AcmeKey {
-    private_key: EcKey<pkey::Private>,
+pub(crate) struct AcmeKey<C: Crypto> where for <'a> &'a C::AccountKey: Into<Jwk> {
+    private_key: C::AccountKey,
     /// set once we contacted the ACME API to figure out the key id
     key_id: Option<String>,
 }
 
-impl AcmeKey {
-    pub(crate) fn new() -> AcmeKey {
-        let pri_key = EcKey::generate(&*EC_GROUP_P256).expect("EcKey");
-        Self::from_key(pri_key)
+impl<C: Crypto> AcmeKey<C> where for <'a> &'a C::AccountKey: Into<Jwk> {
+    pub(crate) fn new() -> Result<Self, C::Error> {
+        C::AccountKey::new().map(Self::from_key)
     }
 
-    pub(crate) fn from_pem(pem: &[u8]) -> Result<AcmeKey> {
-        let pri_key =
-            EcKey::private_key_from_pem(pem).map_err(|e| format!("Failed to read PEM: {}", e))?;
+    pub(crate) fn from_pem(pem: &[u8]) -> Result<Self, C::Error> {
+        let pri_key = C::AccountKey::from_pem(std::str::from_utf8(pem).expect("non-utf8")).expect("cannot parse pem");
         Ok(Self::from_key(pri_key))
     }
 
-    fn from_key(private_key: EcKey<pkey::Private>) -> AcmeKey {
+    fn from_key(private_key: C::AccountKey) -> Self {
         AcmeKey {
             private_key,
             key_id: None,
         }
     }
 
-    pub(crate) fn to_pem(&self) -> Vec<u8> {
-        self.private_key
-            .private_key_to_pem()
-            .expect("private_key_to_pem")
+    pub(crate) fn to_pem(&self) -> String {
+        self.private_key.to_pem().expect("private_key_to_pem")
     }
 
-    pub(crate) fn private_key(&self) -> &EcKey<pkey::Private> {
+    pub(crate) fn private_key(&self) -> &C::AccountKey {
         &self.private_key
     }
 
@@ -46,5 +39,9 @@ impl AcmeKey {
 
     pub(crate) fn set_key_id(&mut self, kid: String) {
         self.key_id = Some(kid)
+    }
+
+    pub(crate) fn sign(&self, data: &[u8]) -> Vec<u8> {
+        self.private_key.sign(data).expect("Could not sign data")
     }
 }

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -1,156 +1,50 @@
-use lazy_static::lazy_static;
-use openssl::ec::{Asn1Flag, EcGroup, EcKey};
-use openssl::hash::MessageDigest;
-use openssl::nid::Nid;
-use openssl::pkey::{self, PKey};
-use openssl::rsa::Rsa;
-use openssl::stack::Stack;
-use openssl::x509::extension::SubjectAlternativeName;
-use openssl::x509::{X509Req, X509ReqBuilder, X509};
+// use crate::crypto::Crypto;
 
-use crate::Result;
-
-lazy_static! {
-    pub(crate) static ref EC_GROUP_P256: EcGroup = ec_group(Nid::X9_62_PRIME256V1);
-    pub(crate) static ref EC_GROUP_P384: EcGroup = ec_group(Nid::SECP384R1);
-}
-
-fn ec_group(nid: Nid) -> EcGroup {
-    let mut g = EcGroup::from_curve_name(nid).expect("EcGroup");
-    // this is required for openssl 1.0.x (but not 1.1.x)
-    g.set_asn1_flag(Asn1Flag::NAMED_CURVE);
-    g
-}
-
-/// Make an RSA private key (from which we can derive a public key).
-///
-/// This library does not check the number of bits used to create the key pair.
-/// For Let's Encrypt, the bits must be between 2048 and 4096.
-pub fn create_rsa_key(bits: u32) -> PKey<pkey::Private> {
-    let pri_key_rsa = Rsa::generate(bits).expect("Rsa::generate");
-    PKey::from_rsa(pri_key_rsa).expect("from_rsa")
-}
-
-/// Make a P-256 private key (from which we can derive a public key).
-pub fn create_p256_key() -> PKey<pkey::Private> {
-    let pri_key_ec = EcKey::generate(&*EC_GROUP_P256).expect("EcKey");
-    PKey::from_ec_key(pri_key_ec).expect("from_ec_key")
-}
-
-/// Make a P-384 private key pair (from which we can derive a public key).
-pub fn create_p384_key() -> PKey<pkey::Private> {
-    let pri_key_ec = EcKey::generate(&*EC_GROUP_P384).expect("EcKey");
-    PKey::from_ec_key(pri_key_ec).expect("from_ec_key")
-}
-
-pub(crate) fn create_csr(pkey: &PKey<pkey::Private>, domains: &[&str]) -> Result<X509Req> {
-    //
-    // the csr builder
-    let mut req_bld = X509ReqBuilder::new().expect("X509ReqBuilder");
-
-    // set private/public key in builder
-    req_bld.set_pubkey(pkey).expect("set_pubkey");
-
-    // set all domains as alt names
-    let mut stack = Stack::new().expect("Stack::new");
-    let ctx = req_bld.x509v3_context(None);
-    let as_lst = domains
-        .iter()
-        .map(|&e| format!("DNS:{}", e))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let as_lst = as_lst[4..].to_string();
-    let mut an = SubjectAlternativeName::new();
-    an.dns(&as_lst);
-    let ext = an.build(&ctx).expect("SubjectAlternativeName::build");
-    stack.push(ext).expect("Stack::push");
-    req_bld.add_extensions(&stack).expect("add_extensions");
-
-    // sign it
-    req_bld
-        .sign(pkey, MessageDigest::sha256())
-        .expect("csr_sign");
-
-    // the csr
-    Ok(req_bld.build())
-}
-
-/// Encapsulated certificate and private key.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Certificate {
-    private_key: String,
-    certificate: String,
-}
-
-impl Certificate {
-    pub(crate) fn new(private_key: String, certificate: String) -> Self {
-        Certificate {
-            private_key,
-            certificate,
-        }
-    }
-
-    /// The PEM encoded private key.
-    pub fn private_key(&self) -> &str {
-        &self.private_key
-    }
-
-    /// The private key as DER.
-    pub fn private_key_der(&self) -> Vec<u8> {
-        let pkey = PKey::private_key_from_pem(self.private_key.as_bytes()).expect("from_pem");
-        pkey.private_key_to_der().expect("private_key_to_der")
-    }
-
-    /// The PEM encoded issued certificate.
-    pub fn certificate(&self) -> &str {
-        &self.certificate
-    }
-
-    /// The issued certificate as DER.
-    pub fn certificate_der(&self) -> Vec<u8> {
-        let x509 = X509::from_pem(self.certificate.as_bytes()).expect("from_pem");
-        x509.to_der().expect("to_der")
-    }
-
-    /// Inspect the certificate to count the number of (whole) valid days left.
-    ///
-    /// It's up to the ACME API provider to decide how long an issued certificate is valid.
-    /// Let's Encrypt sets the validity to 90 days. This function reports 89 days for newly
-    /// issued cert, since it counts _whole_ days.
-    ///
-    /// It is possible to get negative days for an expired certificate.
-    pub fn valid_days_left(&self) -> i64 {
-        // the cert used in the tests is not valid to load as x509
-        if cfg!(test) {
-            return 89;
-        }
-
-        // load as x509
-        let x509 = X509::from_pem(self.certificate.as_bytes()).expect("from_pem");
-
-        // convert asn1 time to Tm
-        let not_after = format!("{}", x509.not_after());
-        // Display trait produces this format, which is kinda dumb.
-        // Apr 19 08:48:46 2019 GMT
-        let expires = parse_date(&not_after);
-        let dur = expires - time::now();
-
-        dur.num_days()
-    }
-}
-
-fn parse_date(s: &str) -> time::Tm {
-    debug!("Parse date/time: {}", s);
-    time::strptime(s, "%h %e %H:%M:%S %Y %Z").expect("strptime")
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_parse_date() {
-        let x = parse_date("May  3 07:40:15 2019 GMT");
-        assert_eq!(time::strftime("%F %T", &x).unwrap(), "2019-05-03 07:40:15");
-    }
-}
+// /// Encapsulated certificate and private key.
+// #[derive(Debug, Clone, PartialEq, Eq)]
+// pub struct Certificate<C: Crypto> {
+//     private_key: String,
+//     certificate: String,
+// }
+//
+// impl<C: Crypto> Certificate {
+//     pub(crate) fn new(private_key: String, certificate: String) -> Self {
+//         Certificate {
+//             private_key,
+//             certificate,
+//         }
+//     }
+//
+//     /// The PEM encoded private key.
+//     pub fn private_key(&self) -> &str {
+//         &self.private_key
+//     }
+//
+//     /// The private key as DER.
+//     pub fn private_key_der(&self) -> Vec<u8> {
+//         let pkey = PKey::private_key_from_pem(self.private_key.as_bytes()).expect("from_pem");
+//         pkey.private_key_to_der().expect("private_key_to_der")
+//     }
+//
+//     /// The PEM encoded issued certificate.
+//     pub fn certificate(&self) -> &str {
+//         &self.certificate
+//     }
+//
+//     /// The issued certificate as DER.
+//     pub fn certificate_der(&self) -> Vec<u8> {
+//         let x509 = X509::from_pem(self.certificate.as_bytes()).expect("from_pem");
+//         x509.to_der().expect("to_der")
+//     }
+//
+//     /// Inspect the certificate to count the number of (whole) valid days left.
+//     ///
+//     /// It's up to the ACME API provider to decide how long an issued certificate is valid.
+//     /// Let's Encrypt sets the validity to 90 days. This function reports 89 days for newly
+//     /// issued cert, since it counts _whole_ days.
+//     ///
+//     /// It is possible to get negative days for an expired certificate.
+//     pub fn valid_days_left(&self) -> i64 {
+//     }
+// }
+//

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,46 @@
+use std::fmt::Debug;
+use crate::error;
+use crate::jwt::Jwk;
+
+pub trait PKey: Sized {
+    type Error: Sized + Into<error::Error> + Debug;
+
+    fn from_pem(pem: &str) -> Result<Self, Self::Error>;
+    fn to_pem(&self) -> Result<String, Self::Error>;
+
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
+
+    fn new() -> Result<Self, Self::Error>;
+}
+
+pub trait Csr: Sized {
+    type Error: Sized + Into<error::Error> + Debug;
+    type PrivateKey: PKey<Error=Self::Error> + Debug + Clone;
+
+    fn new(key: &Self::PrivateKey, domains: &[&str]) -> Result<Self, Self::Error>;
+    fn from_pem(pem: &str) -> Result<Self, Self::Error>;
+    fn to_der(&self) -> Result<Vec<u8>, Self::Error>;
+    fn to_pem(&self) -> Result<Vec<u8>, Self::Error>;
+}
+
+pub trait Certificate: Sized {
+    type Error: Sized + Into<error::Error> + Debug;
+
+    fn from_pem(pem: &str) -> Result<Self, Self::Error>;
+    fn to_pem(&self) -> Result<Vec<u8>, Self::Error>;
+    fn to_der(&self) -> Result<Vec<u8>, Self::Error>;
+
+    fn valid_days_left(&self) -> i64;
+}
+
+
+pub trait Crypto: Clone + Default where for <'a> &'a Self::AccountKey: Into<Jwk>  {
+    type Error: Sized + Into<error::Error> + Debug;
+
+    type AccountKey: PKey<Error=Self::Error> + Debug + Clone;
+    type PrivateKey: PKey<Error=Self::Error> + Debug + Clone;
+    type Csr: Csr<Error=Self::Error, PrivateKey = Self::PrivateKey> + Debug + Clone;
+    type Certificate: Certificate<Error = Self::Error>;
+
+    fn sha256(input: &[u8]) -> [u8; 32];
+}

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,9 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::acc::AcmeKey;
-use crate::cert::EC_GROUP_P256;
-use crate::util::base64url;
-
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct JwsProtected {
     alg: String,
@@ -37,14 +33,14 @@ impl JwsProtected {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub(crate) struct Jwk {
-    alg: String,
-    crv: String,
-    kty: String,
+pub struct Jwk {
+    pub alg: String,
+    pub crv: String,
+    pub kty: String,
     #[serde(rename = "use")]
-    _use: String,
-    x: String,
-    y: String,
+    pub _use: String,
+    pub x: String,
+    pub y: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -54,26 +50,6 @@ pub(crate) struct JwkThumb {
     kty: String,
     x: String,
     y: String,
-}
-
-impl From<&AcmeKey> for Jwk {
-    fn from(a: &AcmeKey) -> Self {
-        let mut ctx = openssl::bn::BigNumContext::new().expect("BigNumContext");
-        let mut x = openssl::bn::BigNum::new().expect("BigNum");
-        let mut y = openssl::bn::BigNum::new().expect("BigNum");
-        a.private_key()
-            .public_key()
-            .affine_coordinates_gfp(&*EC_GROUP_P256, &mut x, &mut y, &mut ctx)
-            .expect("affine_coordinates_gfp");
-        Jwk {
-            alg: "ES256".into(),
-            kty: "EC".into(),
-            crv: "P-256".into(),
-            _use: "sig".into(),
-            x: base64url(&x.to_vec()),
-            y: base64url(&y.to_vec()),
-        }
-    }
 }
 
 impl From<&Jwk> for JwkThumb {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,13 +153,13 @@
 extern crate log;
 
 mod acc;
-mod cert;
 mod dir;
 mod error;
 mod jwt;
 mod req;
 mod trans;
 mod util;
+mod crypto;
 
 pub mod api;
 pub mod order;
@@ -168,11 +168,13 @@ pub mod persist;
 #[cfg(feature = "ureq")]
 pub mod ureq;
 
+#[cfg(feature = "openssl")]
+pub mod openssl;
+
 
 #[cfg(test)]
 mod test;
 
 pub use crate::acc::{Account, RevocationReason};
-pub use crate::cert::{create_p256_key, create_p384_key, create_rsa_key, Certificate};
 pub use crate::dir::{Directory, DirectoryUrl};
 pub use crate::error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,10 @@ pub mod api;
 pub mod order;
 pub mod persist;
 
+#[cfg(feature = "ureq")]
+pub mod ureq;
+
+
 #[cfg(test)]
 mod test;
 

--- a/src/openssl.rs
+++ b/src/openssl.rs
@@ -1,0 +1,286 @@
+use std::fmt::{Debug, Formatter};
+use std::ops::{Deref, DerefMut};
+use lazy_static::lazy_static;
+use crate::crypto::{Certificate, Crypto, Csr, PKey};
+
+use openssl::pkey;
+use openssl::ec;
+use openssl::ec::{Asn1Flag, EcGroup, EcKey};
+use openssl::ecdsa::EcdsaSig;
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::rsa::Rsa;
+use openssl::stack::Stack;
+use openssl::x509::{X509, X509Req, X509ReqBuilder};
+use openssl::x509::extension::SubjectAlternativeName;
+use crate::jwt::Jwk;
+use crate::util::{base64url};
+
+lazy_static! {
+    pub(crate) static ref EC_GROUP_P256: EcGroup = ec_group(Nid::X9_62_PRIME256V1);
+    pub(crate) static ref EC_GROUP_P384: EcGroup = ec_group(Nid::SECP384R1);
+}
+
+fn ec_group(nid: Nid) -> EcGroup {
+    let mut g = EcGroup::from_curve_name(nid).expect("EcGroup");
+    // this is required for openssl 1.0.x (but not 1.1.x)
+    g.set_asn1_flag(Asn1Flag::NAMED_CURVE);
+    g
+}
+
+
+#[derive(Copy, Clone, Default)]
+pub struct Openssl;
+
+pub struct NewType<T>(T);
+
+impl PKey for NewType<pkey::PKey<pkey::Private>> {
+    type Error = openssl::error::ErrorStack;
+
+    fn from_pem(pem: &str) -> Result<Self, Self::Error> {
+        let rsa = openssl::rsa::Rsa::<pkey::Private>::private_key_from_pem(pem.as_bytes())?;
+        pkey::PKey::from_rsa(rsa).map(NewType)
+
+    }
+
+    fn to_pem(&self) -> Result<String, Self::Error> {
+        self.private_key_to_pem_pkcs8().map( |pem| String::from_utf8_lossy(&pem).into_owned())
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        let mut signer = openssl::sign::Signer::new(MessageDigest::sha256(), &self.0)?;
+        signer.update(data)?;
+        signer.sign_to_vec()
+    }
+
+    fn new() -> Result<Self, Self::Error> {
+        let pri_key_rsa = Rsa::generate(2048)?;
+        pkey::PKey::from_rsa(pri_key_rsa).map(NewType)
+    }
+}
+
+impl PKey for NewType<ec::EcKey<pkey::Private>> {
+    type Error = openssl::error::ErrorStack;
+
+    fn from_pem(pem: &str) -> Result<Self, Self::Error> {
+        openssl::ec::EcKey::private_key_from_pem(pem.as_bytes()).map(NewType)
+    }
+
+    fn to_pem(&self) -> Result<String, Self::Error> {
+        self.private_key_to_pem().map(|c| String::from_utf8_lossy(&c).into_owned())
+    }
+
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
+        let digest = Openssl::sha256(data);
+        let sig = EcdsaSig::sign(&digest, &self.0)?;
+
+        let r = sig.r().to_vec();
+        let s = sig.s().to_vec();
+
+        let mut v = Vec::with_capacity(r.len() + s.len());
+        v.extend_from_slice(&r);
+        v.extend_from_slice(&s);
+
+        Ok(v)
+    }
+
+    fn new() -> Result<Self, Self::Error> {
+        EcKey::generate(&*EC_GROUP_P384).map(NewType)
+    }
+}
+
+
+
+impl<T> Deref for NewType<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for NewType<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a> From<&'a <Openssl as Crypto>::AccountKey> for Jwk {
+    fn from(key: &'a <Openssl as Crypto>::AccountKey) -> Self {
+        let mut ctx = openssl::bn::BigNumContext::new().expect("BigNumContext");
+        let mut x = openssl::bn::BigNum::new().expect("BigNum");
+        let mut y = openssl::bn::BigNum::new().expect("BigNum");
+        key.public_key()
+            .affine_coordinates_gfp(&*EC_GROUP_P256, &mut x, &mut y, &mut ctx)
+            .expect("affine_coordinates_gfp");
+        Jwk {
+            alg: "ES256".into(),
+            kty: "EC".into(),
+            crv: "P-256".into(),
+            _use: "sig".into(),
+            x: base64url(&x.to_vec()),
+            y: base64url(&y.to_vec()),
+        }
+    }
+}
+
+
+// /// Make a P-256 private key (from which we can derive a public key).
+// pub fn create_p256_key() -> PKey<pkey::Private> {
+//     let pri_key_ec = EcKey::generate(&*EC_GROUP_P256).expect("EcKey");
+//     PKey::from_ec_key(pri_key_ec).expect("from_ec_key")
+// }
+
+impl Csr for NewType<X509Req> {
+    type Error = openssl::error::ErrorStack;
+    type PrivateKey = NewType<pkey::PKey<pkey::Private>>;
+
+    fn new(pkey: &Self::PrivateKey, domains: &[&str]) -> Result<Self, Self::Error> {
+        //
+        // the csr builder
+        let mut req_bld = X509ReqBuilder::new().expect("X509ReqBuilder");
+
+        // set private/public key in builder
+        req_bld.set_pubkey(pkey).expect("set_pubkey");
+
+        // set all domains as alt names
+        let mut stack = Stack::new().expect("Stack::new");
+        let ctx = req_bld.x509v3_context(None);
+        let as_lst = domains
+            .iter()
+            .map(|&e| format!("DNS:{}", e))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let as_lst = as_lst[4..].to_string();
+        let mut an = SubjectAlternativeName::new();
+        an.dns(&as_lst);
+        let ext = an.build(&ctx).expect("SubjectAlternativeName::build");
+        stack.push(ext).expect("Stack::push");
+        req_bld.add_extensions(&stack).expect("add_extensions");
+
+        // sign it
+        req_bld
+            .sign(pkey, MessageDigest::sha256())
+            .expect("csr_sign");
+
+        // the csr
+        Ok(NewType(req_bld.build()))
+    }
+
+    fn to_pem(&self) -> Result<Vec<u8>, Self::Error> {
+        self.0.to_pem()
+    }
+
+    fn to_der(&self) -> Result<Vec<u8>, Self::Error> {
+        self.0.to_der()
+    }
+
+    fn from_pem(pem: &str) -> Result<Self, Self::Error> {
+        X509Req::from_pem(pem.as_bytes()).map(NewType)
+    }
+}
+
+impl Certificate for NewType<X509> {
+    type Error = openssl::error::ErrorStack;
+
+    fn from_pem(pem: &str) -> Result<Self, Self::Error> {
+        X509::from_pem(pem.as_bytes()).map(NewType)
+    }
+
+    fn to_pem(&self) -> Result<Vec<u8>, Self::Error> {
+        self.0.to_pem()
+    }
+
+    fn to_der(&self) -> Result<Vec<u8>, Self::Error> {
+        self.0.to_der()
+    }
+
+    fn valid_days_left(&self) -> i64 {
+        // the cert used in the tests is not valid to load as x509
+        if cfg!(test) {
+            return 89;
+        }
+
+        // convert asn1 time to Tm
+        let not_after = format!("{}", self.0.not_after());
+        // Display trait produces this format, which is kinda dumb.
+        // Apr 19 08:48:46 2019 GMT
+        let expires = parse_date(&not_after);
+        let dur = expires - time::now();
+
+        dur.num_days()
+    }
+}
+
+impl Debug for NewType<X509> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an X509 certificate")
+    }
+}
+
+impl Debug for NewType<X509Req> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("an X509 certificate request")
+    }
+}
+
+impl Debug for NewType<pkey::PKey<pkey::Private>> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a private rsa key")
+    }
+}
+
+impl Clone for NewType<pkey::PKey<pkey::Private>> {
+    fn clone(&self) -> Self {
+        let pem = self.to_pem().expect("to pem");
+        Self::from_pem(&pem).expect("from pem")
+    }
+}
+
+impl Debug for NewType<EcKey<pkey::Private>> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a private rsa key")
+    }
+}
+
+impl Clone for NewType<EcKey<pkey::Private>> {
+    fn clone(&self) -> Self {
+        let pem = self.to_pem().expect("to pem");
+        Self::from_pem(&pem).expect("from pem")
+    }
+}
+
+impl Clone for NewType<X509Req> {
+    fn clone(&self) -> Self {
+        let pem = self.to_pem().expect("to pem");
+        let pem = std::str::from_utf8(&pem).expect("from utf8");
+        Self::from_pem(&pem).expect("from pem")
+    }
+}
+
+impl From<ErrorStack> for crate::Error {
+    fn from(_: ErrorStack) -> Self {
+        Self::Other("An openssl Error".to_string())
+    }
+}
+
+
+impl Crypto for Openssl {
+    type Error = openssl::error::ErrorStack;
+
+    type AccountKey = NewType<ec::EcKey<pkey::Private>>;
+    type PrivateKey = NewType<pkey::PKey<pkey::Private>>;
+
+    type Csr = NewType<X509Req>;
+    type Certificate = NewType<X509>;
+
+    fn sha256(input: &[u8]) -> [u8; 32] {
+        openssl::sha::sha256(input)
+    }
+}
+
+pub(crate) fn parse_date(s: &str) -> time::Tm {
+    debug!("Parse date/time: {}", s);
+    time::strptime(s, "%h %e %H:%M:%S %Y %Z").expect("strptime")
+}

--- a/src/req.rs
+++ b/src/req.rs
@@ -1,84 +1,20 @@
 use crate::api::ApiProblem;
 
-pub(crate) type ReqResult<T> = std::result::Result<T, ApiProblem>;
+pub(crate) type HttpResult<T> = Result<T, ApiProblem>;
 
-pub(crate) fn req_get(url: &str) -> ureq::Response {
-    let mut req = ureq::get(url);
-    req_configure(&mut req);
-    trace!("{:?}", req);
-    req.call()
+
+pub trait HttpResponse: Sized {
+    fn body(self) -> String;
+    fn header(&self, name: &str) -> HttpResult<&str>;
+
+    fn handle_errors(self) -> HttpResult<Self>;
 }
 
-pub(crate) fn req_head(url: &str) -> ureq::Response {
-    let mut req = ureq::head(url);
-    req_configure(&mut req);
-    trace!("{:?}", req);
-    req.call()
+pub trait HttpClient: Clone + Sized {
+    type Response: HttpResponse;
+
+    fn get(&self, url: &str) -> Self::Response;
+    fn head(&self, url: &str) -> Self::Response;
+    fn post(&self, url: &str, body: &str) -> Self::Response;
 }
 
-pub(crate) fn req_post(url: &str, body: &str) -> ureq::Response {
-    let mut req = ureq::post(url);
-    req.set("content-type", "application/jose+json");
-    req_configure(&mut req);
-    trace!("{:?} {}", req, body);
-    req.send_string(body)
-}
-
-fn req_configure(req: &mut ureq::Request) {
-    req.timeout_connect(30_000);
-    req.timeout_read(30_000);
-    req.timeout_write(30_000);
-}
-
-pub(crate) fn req_handle_error(res: ureq::Response) -> ReqResult<ureq::Response> {
-    // ok responses pass through
-    if res.ok() {
-        return Ok(res);
-    }
-
-    let problem = if res.content_type() == "application/problem+json" {
-        // if we were sent a problem+json, deserialize it
-        let body = req_safe_read_body(res);
-        serde_json::from_str(&body).unwrap_or_else(|e| ApiProblem {
-            _type: "problemJsonFail".into(),
-            detail: Some(format!(
-                "Failed to deserialize application/problem+json ({}) body: {}",
-                e.to_string(),
-                body
-            )),
-            subproblems: None,
-        })
-    } else {
-        // some other problem
-        let status = format!("{} {}", res.status(), res.status_text());
-        let body = req_safe_read_body(res);
-        let detail = format!("{} body: {}", status, body);
-        ApiProblem {
-            _type: "httpReqError".into(),
-            detail: Some(detail),
-            subproblems: None,
-        }
-    };
-
-    Err(problem)
-}
-
-pub(crate) fn req_expect_header(res: &ureq::Response, name: &str) -> ReqResult<String> {
-    res.header(name)
-        .map(|v| v.to_string())
-        .ok_or_else(|| ApiProblem {
-            _type: format!("Missing header: {}", name),
-            detail: None,
-            subproblems: None,
-        })
-}
-
-pub(crate) fn req_safe_read_body(res: ureq::Response) -> String {
-    use std::io::Read;
-    let mut res_body = String::new();
-    let mut read = res.into_reader();
-    // letsencrypt sometimes closes the TLS abruptly causing io error
-    // even though we did capture the body.
-    read.read_to_string(&mut res_body).ok();
-    res_body
-}

--- a/src/ureq.rs
+++ b/src/ureq.rs
@@ -2,7 +2,7 @@ use crate::api::ApiProblem;
 use crate::req::{HttpClient, HttpResponse, HttpResult};
 
 #[derive(Copy, Clone, Default)]
-pub struct UReq();
+pub struct UReq;
 
 impl HttpClient for UReq {
     type Response = ureq::Response;

--- a/src/ureq.rs
+++ b/src/ureq.rs
@@ -1,0 +1,93 @@
+use crate::api::ApiProblem;
+use crate::req::{HttpClient, HttpResponse, HttpResult};
+
+#[derive(Copy, Clone, Default)]
+pub struct UReq();
+
+impl HttpClient for UReq {
+    type Response = ureq::Response;
+
+    fn get(&self, url: &str) -> Self::Response {
+        let mut req = ureq::get(url);
+        Self::set_timeouts(&mut req);
+        trace!("{:?}", req);
+        req.call()
+    }
+
+    fn head(&self, url: &str) -> Self::Response {
+        let mut req = ureq::head(url);
+        Self::set_timeouts(&mut req);
+        trace!("{:?}", req);
+        req.call()
+    }
+
+    fn post(&self, url: &str, body: &str) -> Self::Response {
+        let mut req = ureq::post(url);
+        req.set("content-type", "application/jose+json");
+        Self::set_timeouts(&mut req);
+        trace!("{:?} {}", req, body);
+        req.send_string(body)
+    }
+}
+
+impl UReq {
+    fn set_timeouts(req: &mut ureq::Request) {
+        req.timeout_connect(30_000);
+        req.timeout_read(30_000);
+        req.timeout_write(30_000);
+    }
+}
+
+impl HttpResponse for ureq::Response {
+    fn body(self) -> String {
+        use std::io::Read;
+        let mut res_body = String::new();
+        let mut read = self.into_reader();
+        // letsencrypt sometimes closes the TLS abruptly causing io error
+        // even though we did capture the body.
+        read.read_to_string(&mut res_body).ok();
+        res_body
+    }
+
+    fn header(&self, name: &str) -> HttpResult<&str> {
+        self.header(name)
+            .ok_or_else(|| ApiProblem {
+                _type: format!("Missing header: {}", name),
+                detail: None,
+                subproblems: None,
+            })
+    }
+
+    fn handle_errors(self) -> HttpResult<Self> {
+        // ok responses pass through
+        if self.ok() {
+            return Ok(self);
+        }
+
+        let problem = if self.content_type() == "application/problem+json" {
+            // if we were sent a problem+json, deserialize it
+            let body = self.body();
+            serde_json::from_str(&body).unwrap_or_else(|e| ApiProblem {
+                _type: "problemJsonFail".into(),
+                detail: Some(format!(
+                    "Failed to deserialize application/problem+json ({}) body: {}",
+                    e.to_string(),
+                    body
+                )),
+                subproblems: None,
+            })
+        } else {
+            // some other problem
+            let status = format!("{} {}", self.status(), self.status_text());
+            let body = self.body();
+            let detail = format!("{} body: {}", status, body);
+            ApiProblem {
+                _type: "httpReqError".into(),
+                detail: Some(detail),
+                subproblems: None,
+            }
+        };
+
+        Err(problem)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,3 +18,14 @@ pub(crate) fn read_json<T: DeserializeOwned>(res: impl HttpResponse) -> Result<T
     debug!("{}", res_body);
     Ok(serde_json::from_str(&res_body)?)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_date() {
+        let x = parse_date("May  3 07:40:15 2019 GMT");
+        assert_eq!(time::strftime("%F %T", &x).unwrap(), "2019-05-03 07:40:15");
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use serde::de::DeserializeOwned;
+use crate::req::HttpResponse;
 
-use crate::req::req_safe_read_body;
 use crate::Result;
 
 lazy_static! {
@@ -13,8 +13,8 @@ pub(crate) fn base64url<T: ?Sized + AsRef<[u8]>>(input: &T) -> String {
     base64::encode_config(input, *BASE64_CONFIG)
 }
 
-pub(crate) fn read_json<T: DeserializeOwned>(res: ureq::Response) -> Result<T> {
-    let res_body = req_safe_read_body(res);
+pub(crate) fn read_json<T: DeserializeOwned>(res: impl HttpResponse) -> Result<T> {
+    let res_body = res.body();
     debug!("{}", res_body);
     Ok(serde_json::from_str(&res_body)?)
 }


### PR DESCRIPTION
This is useful for embedded environments where the http client / TLS implementation is supplied by the operating system, and cannot use ureq as a dependency.