### PR TITLE
Fix SANs in CSR

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -54,14 +54,11 @@ pub(crate) fn create_csr(pkey: &PKey<pkey::Private>, domains: &[&str]) -> Result
     // set all domains as alt names
     let mut stack = Stack::new().expect("Stack::new");
     let ctx = req_bld.x509v3_context(None);
-    let as_lst = domains
-        .iter()
-        .map(|&e| format!("DNS:{}", e))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let as_lst = as_lst[4..].to_string();
     let mut an = SubjectAlternativeName::new();
-    an.dns(&as_lst);
+    for d in domains {
+        an.dns(d);
+    }
+
     let ext = an.build(&ctx).expect("SubjectAlternativeName::build");
     stack.push(ext).expect("Stack::push");
     req_bld.add_extensions(&stack).expect("add_extensions");


### PR DESCRIPTION
Release 0.10.48 broke our SAN generation such that calling

```rust
an.dns("*.example.com,DNS:example.com")
```

Did not result in a SAN extension that Golang's
`ParseCertificateRequest` would parse into two distinct SANs, instead it
would consider it to be a single SAN.

Calling `an.dns` for each domain resolves this.
