### PR TITLE
Bug Fix: Multiple Domain Names for Single Certificate

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -54,14 +54,10 @@ pub(crate) fn create_csr(pkey: &PKey<pkey::Private>, domains: &[&str]) -> Result
     // set all domains as alt names
     let mut stack = Stack::new().expect("Stack::new");
     let ctx = req_bld.x509v3_context(None);
-    let as_lst = domains
-        .iter()
-        .map(|&e| format!("DNS:{}", e))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let as_lst = as_lst[4..].to_string();
     let mut an = SubjectAlternativeName::new();
-    an.dns(&as_lst);
+    for domain in domains.into_iter() {
+        an.dns(domain);
+    }
     let ext = an.build(&ctx).expect("SubjectAlternativeName::build");
     stack.push(ext).expect("Stack::push");
     req_bld.add_extensions(&stack).expect("add_extensions");


### PR DESCRIPTION
# Fix
Hello, I discovered an issue with `acme-lib` when a certificate that covers multiple domains is created.

When requesting a new cert, the domains the certificate covers are sent to the desired certificate authority all together in a single logical "alternate domain" field. This causes an error as there are multiple domains in a field expecting one, the solution was to call the `.dns` method multiple times and loop through the domains instead of concatenating them into a single string so that each domain gets its own logical "alternate domain" field.

I ran into this issue when attempting to create certificates with both the live version of Let's Encrypt and their staging version.