### PR TITLE
Use NO_PAD for base64url

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use crate::req::req_safe_read_body;
 use crate::Result;
 
 pub(crate) fn base64url<T: ?Sized + AsRef<[u8]>>(input: &T) -> String {
-    base64::prelude::BASE64_URL_SAFE.encode(input)
+    base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(input)
 }
 
 pub(crate) fn read_json<T: DeserializeOwned>(res: ureq::Response) -> Result<T> {


### PR DESCRIPTION
Use `NO_PAD` for base64url encoding

fixes #63 